### PR TITLE
Feature: upgrade xpcc to modm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "embedded/modm"]
+	path = embedded/modm
+	url = https://github.com/modm-io/modm.git

--- a/embedded/firmware/.gitignore
+++ b/embedded/firmware/.gitignore
@@ -2,3 +2,9 @@ build/
 *.bak
 .sconsign.dblite
 *.gch
+
+# unsure wether to include it or not
+# modm recomends to check them into git
+# @see(https://modm.io/guide/getting-started/#generate-and-compile)
+modm/
+project.xml.log

--- a/embedded/firmware/SConstruct
+++ b/embedded/firmware/SConstruct
@@ -1,4 +1,52 @@
-# path to the xpcc root directory
-xpccpath = '../xpcc'
-# execute the common SConstruct file
-execfile(xpccpath + '/scons/SConstruct')
+# Copyright (c) 2017-2018, Niklas Hauser
+#
+# This file is part of the modm project.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#!/usr/bin/env python3
+
+import os
+from os.path import join, abspath
+
+# User Configurable Options
+project_name = "ux0firmware"
+build_path = "build"
+generated_paths = ['modm']
+# SCons environment with all tools
+env = DefaultEnvironment(tools=[], ENV=os.environ)
+env["CONFIG_BUILD_BASE"] = abspath(build_path)
+env["CONFIG_ARTIFACT_PATH"] = join(env["CONFIG_BUILD_BASE"], "artifact")
+env["CONFIG_PROJECT_NAME"] = project_name
+env["CONFIG_PROFILE"] = ARGUMENTS.get("profile", "release")
+
+# Building all libraries
+env.SConscript(dirs=generated_paths, exports="env")
+
+env.Append(CPPPATH=".")
+ignored = [".lbuild_cache", build_path] + generated_paths
+sources = []
+# Finding application sources
+sources += env.FindSourceFiles(".", ignorePaths=ignored)
+# So you want to add or remove compile options?
+#   0. Check what options you want to add to GCC:
+#      https://gcc.gnu.org/onlinedocs/gcc/Option-Summary.html
+#   1. Check what the environment variables are called in SCons:
+#      https://www.scons.org/doc/latest/HTML/scons-user/apa.html
+#   2. You can append one or multiple options like this
+#       env.Append(CCFLAGS="-pedantic")
+#       env.Append(CCFLAGS=["-pedantic", "-pedantic-errors"])
+#   3. If you need to remove options, you need to do this:
+#       env["CCFLAGS"].remove("-pedantic")
+#      Note that a lot of options also have a "-no-{option}" option
+#      that may overwrite previous options.
+#   4. Add your environment changes below these instructions
+#      inside this SConstruct file.
+#   5. COMMIT THIS SCONSTRUCT FILE NOW!
+#   6. Tell lbuild not to overwrite this SConstruct file anymore:
+#       <option name="modm:build:scons:include_sconstruct">False</option>
+#   7. Anyone using your project now also benefits from your environment changes.
+
+env.BuildTarget(sources)

--- a/embedded/firmware/boards/sensorimotor_rev1_1.hpp
+++ b/embedded/firmware/boards/sensorimotor_rev1_1.hpp
@@ -103,7 +103,7 @@ initialize()
 	motor::DIS::setOutput();
 
 	/* connect and setup uart */
-	Uart0::connect<GpioOutputD1::Txd, GpioInputD0::Rxd>();
+	Uart0::connect<D1::Txd, D0::Rxd>();
 	Uart0::initialize<systemClock, 1_MBd>(); // 1Mbaud/s
 
 	/* connect and setup I2C */

--- a/embedded/firmware/boards/sensorimotor_rev1_1.hpp
+++ b/embedded/firmware/boards/sensorimotor_rev1_1.hpp
@@ -103,15 +103,12 @@ initialize()
 	motor::DIS::setOutput();
 
 	/* connect and setup uart */
-	D0::setInput(Gpio::InputType::PullUp);
-	D0::connect(Uart0::Rx);
-	D1::connect(Uart0::Tx);
-	Uart0::initialize<systemClock, Uart0::Baudrate::MBps1>(); // 1Mbaud/s
+	Uart0::connect<GpioOutputD1::Txd, GpioInputD0::Rxd>();
+	Uart0::initialize<systemClock, 1_MBd>(); // 1Mbaud/s
 
 	/* connect and setup I2C */
-	i2c::SDA::connect(I2cMaster::Sda);
-	i2c::SCL::connect(I2cMaster::Scl);
-	I2cMaster::initialize<systemClock, I2cMaster::Baudrate::Fast>();
+	I2cMaster::connect<i2c::SDA::Sda, i2c::SCL::Scl>();
+	I2cMaster::initialize<systemClock, 400_kBd>();
 
 	enableInterrupts();
 }

--- a/embedded/firmware/boards/sensorimotor_rev1_1.hpp
+++ b/embedded/firmware/boards/sensorimotor_rev1_1.hpp
@@ -11,14 +11,15 @@
 #ifndef SUPREME_SENSORIMOTOR_REV1_1_HPP
 #define SUPREME_SENSORIMOTOR_REV1_1_HPP
 
-#include <xpcc/architecture/platform.hpp>
+#include <modm/platform.hpp>
 
-using namespace xpcc::atmega;
+using namespace modm::literals;
+using namespace modm::platform;
 
 namespace Board
 {
 
-using systemClock = xpcc::avr::SystemClock;
+using systemClock = modm::platform::SystemClock;
 
 /* Arduino-compatible pin names */
 using A0 = GpioC0;

--- a/embedded/firmware/external/adxl345.hpp
+++ b/embedded/firmware/external/adxl345.hpp
@@ -38,13 +38,13 @@
 #ifndef SUPREME_ADXL345_HPP
 #define SUPREME_ADXL345_HPP
 
-#include <xpcc/architecture/platform.hpp>
-#include <xpcc/processing/timer.hpp>
-#include <xpcc/processing/protothread.hpp>
-#include <xpcc/processing/resumable.hpp>
-#include <xpcc/architecture/interface/i2c_device.hpp>
+#include <modm/platform.hpp>
+#include <modm/processing/timer.hpp>
+#include <modm/processing/protothread.hpp>
+#include <modm/processing/resumable.hpp>
+#include <modm/architecture/interface/i2c_device.hpp>
 
-namespace xpcc
+namespace modm
 {
 	namespace adxl345
 	{
@@ -185,7 +185,7 @@ namespace xpcc
 	 * \tparam I2cMaster Asynchronous Two Wire interface
 	 */
 	template < typename I2cMaster >
-	class Adxl345 : /*protected xpcc::I2cWriteReadTransaction*/ public xpcc::I2cDevice<I2cMaster, 2>
+	class Adxl345 : /*protected modm::I2cWriteReadTransaction*/ public modm::I2cDevice<I2cMaster, 2>
 	{
 	public:
 		/**
@@ -229,7 +229,7 @@ namespace xpcc
 		bool
 		isDataReady();
 
-		xpcc::ResumableResult<void>
+		modm::ResumableResult<void>
 		update();
 
 	private:

--- a/embedded/firmware/external/adxl345_impl.hpp
+++ b/embedded/firmware/external/adxl345_impl.hpp
@@ -42,8 +42,8 @@
 
 // ----------------------------------------------------------------------------
 template < typename I2cMaster >
-xpcc::Adxl345<I2cMaster>::Adxl345(uint8_t* data, uint8_t address)
-: xpcc::I2cDevice<I2cMaster, 2>(address), status(0), data(data)
+modm::Adxl345<I2cMaster>::Adxl345(uint8_t* data, uint8_t address)
+: modm::I2cDevice<I2cMaster, 2>(address), status(0), data(data)
 {
 	this->transaction.configureWriteRead(buffer, 0, data, 0);
 }
@@ -51,7 +51,7 @@ xpcc::Adxl345<I2cMaster>::Adxl345(uint8_t* data, uint8_t address)
 /* blocking */
 template < typename I2cMaster >
 bool
-xpcc::Adxl345<I2cMaster>::configure(adxl345::Bandwidth bandwidth, bool streamMode, bool enableInterrupt)
+modm::Adxl345<I2cMaster>::configure(adxl345::Bandwidth bandwidth, bool streamMode, bool enableInterrupt)
 {
 	bool ok = writeRegister(adxl345::REGISTER_POWER_CTL, adxl345::POWER_MEASURE);
 	ok &= writeRegister(adxl345::REGISTER_DATA_FORMAT, adxl345::DATAFORMAT_FULL_RES);
@@ -63,28 +63,28 @@ xpcc::Adxl345<I2cMaster>::configure(adxl345::Bandwidth bandwidth, bool streamMod
 
 template < typename I2cMaster >
 void
-xpcc::Adxl345<I2cMaster>::readAccelerometer()
+modm::Adxl345<I2cMaster>::readAccelerometer()
 {
 	status |= READ_ACCELEROMETER_PENDING;
 }
 
 template < typename I2cMaster >
 bool
-xpcc::Adxl345<I2cMaster>::isDataReady()
+modm::Adxl345<I2cMaster>::isDataReady()
 {
 	return readRegister(adxl345::REGISTER_INT_SOURCE) & adxl345::INTERRUPT_DATA_READY;
 }
 
 template < typename I2cMaster >
 bool
-xpcc::Adxl345<I2cMaster>::isNewDataAvailable()
+modm::Adxl345<I2cMaster>::isNewDataAvailable()
 {
 	return status & NEW_ACCELEROMETER_DATA;
 }
 
 template < typename I2cMaster >
 uint8_t*
-xpcc::Adxl345<I2cMaster>::getData()
+modm::Adxl345<I2cMaster>::getData()
 {
 	status &= ~NEW_ACCELEROMETER_DATA;
 	return data;
@@ -92,12 +92,12 @@ xpcc::Adxl345<I2cMaster>::getData()
 
 /* non-blocking */
 template < typename I2cMaster >
-xpcc::ResumableResult<void>
-xpcc::Adxl345<I2cMaster>::update()
+modm::ResumableResult<void>
+modm::Adxl345<I2cMaster>::update()
 {
 	RF_BEGIN();
 	if (status & READ_ACCELEROMETER_RUNNING &&
-		this->transaction.getState() == xpcc::I2c::TransactionState::Idle) {
+		this->transaction.getState() == modm::I2c::TransactionState::Idle) {
 		status &= ~READ_ACCELEROMETER_RUNNING;
 		status |= NEW_ACCELEROMETER_DATA;
 	}
@@ -117,9 +117,9 @@ xpcc::Adxl345<I2cMaster>::update()
 /* blocking */
 template <typename I2cMaster>
 bool
-xpcc::Adxl345<I2cMaster>::writeRegister(adxl345::Register reg, uint8_t value)
+modm::Adxl345<I2cMaster>::writeRegister(adxl345::Register reg, uint8_t value)
 {
-	while (this->transaction.getState() == xpcc::I2c::TransactionState::Busy)
+	while (this->transaction.getState() == modm::I2c::TransactionState::Busy)
 		;
 	buffer[0] = reg;
 	buffer[1] = value;
@@ -131,9 +131,9 @@ xpcc::Adxl345<I2cMaster>::writeRegister(adxl345::Register reg, uint8_t value)
 /* blocking */
 template <typename I2cMaster>
 uint8_t
-xpcc::Adxl345<I2cMaster>::readRegister(adxl345::Register reg)
+modm::Adxl345<I2cMaster>::readRegister(adxl345::Register reg)
 {
-	while (this->transaction.getState() == xpcc::I2c::TransactionState::Busy)
+	while (this->transaction.getState() == modm::I2c::TransactionState::Busy)
 		;
 	buffer[0] = reg;
 	this->transaction.configureWriteRead(buffer, 1, buffer, 1);

--- a/embedded/firmware/external/i2c_sensor.hpp
+++ b/embedded/firmware/external/i2c_sensor.hpp
@@ -8,10 +8,10 @@
 #ifndef SUPREME_I2C_SENSOR_HPP
 #define SUPREME_I2C_SENSOR_HPP
 
-#include <xpcc/architecture/platform.hpp>
-#include <xpcc/processing.hpp>
-#include <xpcc/processing/resumable.hpp>
-#include <xpcc/architecture/interface/i2c_master.hpp>
+#include <modm/platform.hpp>
+#include <modm/processing.hpp>
+#include <modm/processing/resumable.hpp>
+#include <modm/architecture/interface/i2c_master.hpp>
 #include <external/adxl345.hpp>
 
 namespace supreme {
@@ -25,7 +25,7 @@ namespace supreme {
  +----------------------------------------------------------------------*/
 
 template <typename SensorType, typename DataType>
-class ReaderThread : public xpcc::pt::Protothread, public xpcc::Resumable<1>
+class ReaderThread : public modm::pt::Protothread, public modm::Resumable<1>
 {
 	SensorType& s;
 	DataType& d;
@@ -51,7 +51,7 @@ public:
 
 private:
 
-	xpcc::ResumableResult<void> step()
+	modm::ResumableResult<void> step()
 	{
 		RF_BEGIN(0);
 
@@ -76,7 +76,7 @@ class ExternalSensor
 {
 	uint8_t data[16];
 
-	typedef xpcc::Adxl345<I2cMaster> sensor_t;
+	typedef modm::Adxl345<I2cMaster> sensor_t;
 	typedef struct Values { int16_t x,y,z; } data_t;
 
 	sensor_t sensor;

--- a/embedded/firmware/main.cpp
+++ b/embedded/firmware/main.cpp
@@ -6,7 +6,7 @@
  | October 2018                    |
  +---------------------------------*/
 
-#include <xpcc/architecture/platform.hpp>
+#include <modm/platform.hpp>
 #include <boards/sensorimotor_rev1_1.hpp>
 #include <system/core.hpp>
 #include <system/communication.hpp>

--- a/embedded/firmware/main.cpp
+++ b/embedded/firmware/main.cpp
@@ -6,6 +6,7 @@
  | October 2018                    |
  +---------------------------------*/
 
+#include <avr/io.h>
 #include <modm/platform.hpp>
 #include <boards/sensorimotor_rev1_1.hpp>
 #include <system/core.hpp>
@@ -13,15 +14,33 @@
 #include <system/adc.hpp>
 #include <external/i2c_sensor.hpp>
 
-/* this is called once TCNT0 = OCR0A = 249 *
- * resulting in a 1 ms cycle time, 1kHz    */
-volatile bool current_state = false;
-ISR (TIMER0_COMPA_vect)
-{
-	current_state = !current_state;
-	xpcc::Clock::increment();
-}
+using namespace std::chrono_literals;
 
+/* FUSES ************************************************************** *
+*                                                                       *
+*        SUT0-----+ +-----CKSEL3                                        *
+*        SUT1----+| |+----CKSEL2                                        *
+*       CKOUT---+|| ||+---CKSEL1                                        *
+*      CKDIV8--+||| |||+--CKSEL0                                        *
+*              |||| ||||                                                *
+* lfuse: 0xCF: 1100.1111                                                *
+*        CKSEL3..1       = 111 : >8 Mhz external oscillator             *
+*        CKSEL0, SUT1..0 = 100 : Ceramic Resonator, slowly rising power *
+*        CKOUT           = 0   : no clock output                        *
+* hfuse: 0xD9 (defaults)                                                *
+* efuse: 0xFD: xxxx.x101 Brownout detection min:2V5 typ:2V7 max:2V9     *
+* fuses explained: http://www.ladyada.net/learn/avr/fuses.html          *
+* calculator: http://www.engbedded.com/fusecalc/                        *
+*                                                                       *
+* atmega328p defaults: lfuse: 0x62, hfuse: 0xD9, efuse 0x07 (0xFF)      *
+* ********************************************************************* */
+FUSES = {
+	.low = 0xCF,
+	.high = 0xD9,
+	.extended = 0xFD,
+};
+
+modm::PeriodicTimer timer{1ms}; // render at 1kHz ideally
 
 int main()
 {
@@ -34,34 +53,20 @@ int main()
 	core_t core;
 	exts_t exts;
 
-	/* Design of the 1kHz main loop:
-	 * 16Mhz clock, prescaler 64 -> 16.000.000 / 64 = 250.000 increments per second
-	 * diveded by 1000 -> 250 increments per ms
-	 * hence, timer compare register to 250-1 -> ISR inc ms counter -> 1kHz loop
-	 *
-	 * configure timer 0:
-	 */
-	TCCR0A = (1<<WGM01);             // CTC mode
-	TCCR0B = (1<<CS01) | (1<<CS00);  // set prescaler to 64
-	OCR0A = 249;                     // set timer compare register to 250-1
-	TIMSK0 = (1<<OCIE0A);            // enable compare interrupt
-
 	unsigned long cycles = 0;
 
 	supreme::communication_ctrl<core_t, exts_t> com(core, exts);
 
-	bool previous_state = false;
 	core.init_sensors();
 	while(1) /* main loop */
 	{
 		com.step();
-		if (current_state != previous_state) {
+		if (timer.execute()) {
 			led::red::set();   // red led on, begin of cycle
 			core.step();
 			supreme::adc::restart();
 			++cycles;
 			led::red::reset(); // red led off, end of cycle
-			previous_state = current_state;
 		} else
 			exts.step();
 	}

--- a/embedded/firmware/project.xml
+++ b/embedded/firmware/project.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<library>
+  <repositories>
+    <repository><path>../modm/repo.lb</path></repository>
+  </repositories>
+  <options>
+    <option name="modm:build:project.name">ux0firmware</option>
+    <option name="modm:build:build.path">build/</option>
+
+    <option name="modm:target">atmega328p-au</option>
+    <option name="modm:platform:core:f_cpu">16000000</option>
+
+    <option name="modm:platform:uart:0:buffer.rx">64</option>
+    <option name="modm:platform:uart:0:buffer.tx">64</option>
+
+    <!-- TODO: compiler flags -->
+    
+    <option name="modm:build:avrdude.port">/dev/ttyUSB0</option>
+    <option name="modm:build:avrdude.programmer">arduino</option>
+    <option name="modm:build:avrdude.baudrate">19200</option>
+    <!-- TODO: avr fuses -->
+
+    <!-- uncomment next line if you need to make changes to the SConstruct file-->
+    <!-- <option name="modm:build:scons:include_sconstruct">False</option> -->
+  </options>
+  <modules>
+    <module>modm:docs</module>
+    <module>modm:build:scons</module>
+    <module>modm:architecture</module>
+    <module>modm:architecture:i2c</module>
+    <module>modm:architecture:i2c.device</module>
+    <module>modm:platform:clock</module>
+    <module>modm:platform:core</module>
+    <module>modm:platform:gpio</module>
+    <module>modm:platform:i2c</module>
+    <module>modm:platform:uart:0</module>
+    <module>modm:processing</module>
+    <module>modm:processing:protothread</module>
+    <module>modm:processing:resumable</module>
+    <module>modm:processing:timer</module>
+  </modules>
+</library>

--- a/embedded/firmware/system/adc.hpp
+++ b/embedded/firmware/system/adc.hpp
@@ -11,7 +11,7 @@
 
 #include <avr/io.h>
 #include <avr/interrupt.h>
-#include <xpcc/architecture/platform.hpp>
+#include <modm/platform.hpp>
 
 /*
 	+-------+-------+------------------------------------------+

--- a/embedded/firmware/system/assert.hpp
+++ b/embedded/firmware/system/assert.hpp
@@ -24,10 +24,10 @@ void blink(uint8_t code) {
 			led::red::set();
 			led::yellow::reset();
 		}
-		modm::delayMilliseconds(250);
+		modm::delay_ms(250);
 		led::red::reset();
 		led::yellow::reset();
-		modm::delayMilliseconds(250);
+		modm::delay_ms(250);
 	}
 	led::red::reset();
 	led::yellow::reset();
@@ -40,7 +40,7 @@ void assert(bool condition, uint8_t code = 0) {
 	led::yellow::reset();
 	while(1) {
 		blink(code);
-		modm::delayMilliseconds(1000);
+		modm::delay_ms(1000);
 	}
 }
 

--- a/embedded/firmware/system/assert.hpp
+++ b/embedded/firmware/system/assert.hpp
@@ -9,7 +9,7 @@
 #ifndef SUPREME_COMMON_ASSERT_HPP
 #define SUPREME_COMMON_ASSERT_HPP
 
-#include <xpcc/architecture/platform.hpp>
+#include <modm/platform.hpp>
 
 namespace supreme {
 
@@ -24,10 +24,10 @@ void blink(uint8_t code) {
 			led::red::set();
 			led::yellow::reset();
 		}
-		xpcc::delayMilliseconds(250);
+		modm::delayMilliseconds(250);
 		led::red::reset();
 		led::yellow::reset();
-		xpcc::delayMilliseconds(250);
+		modm::delayMilliseconds(250);
 	}
 	led::red::reset();
 	led::yellow::reset();
@@ -40,7 +40,7 @@ void assert(bool condition, uint8_t code = 0) {
 	led::yellow::reset();
 	while(1) {
 		blink(code);
-		xpcc::delayMilliseconds(1000);
+		modm::delayMilliseconds(1000);
 	}
 }
 

--- a/embedded/firmware/system/communication.hpp
+++ b/embedded/firmware/system/communication.hpp
@@ -9,7 +9,7 @@
 #ifndef SUPREME_COMMUNICATION_HPP
 #define SUPREME_COMMUNICATION_HPP
 
-#include <xpcc/architecture/platform.hpp>
+#include <modm/platform.hpp>
 #include <avr/eeprom.h>
 #include <system/assert.hpp>
 #include <system/sendbuffer.hpp>

--- a/embedded/firmware/system/sendbuffer.hpp
+++ b/embedded/firmware/system/sendbuffer.hpp
@@ -58,16 +58,16 @@ private:
 
 	// TODO move to (future) communication interface class
 	void send_mode() {
-		modm::delayNanoseconds(50); // wait for signal propagation
+		modm::delay_ns(50); // wait for signal propagation
 		rs485::read_disable::set();
 		rs485::drive_enable::set();
-		modm::delayMicroseconds(1); // wait at least one bit after enabling the driver
+		modm::delay_us(1); // wait at least one bit after enabling the driver
 	}
 	void receive_mode() {
-		modm::delayMicroseconds(1); // wait at least one bit before disabling the driver
+		modm::delay_us(1); // wait at least one bit before disabling the driver
 		rs485::read_disable::reset();
 		rs485::drive_enable::reset();
-		modm::delayNanoseconds(70); // wait for signal propagation
+		modm::delay_ns(70); // wait for signal propagation
 	}
 };
 

--- a/embedded/firmware/system/sendbuffer.hpp
+++ b/embedded/firmware/system/sendbuffer.hpp
@@ -9,7 +9,7 @@
 #ifndef SUPREME_SENDBUFFER_HPP
 #define SUPREME_SENDBUFFER_HPP
 
-#include <xpcc/architecture/platform.hpp>
+#include <modm/platform.hpp>
 #include <system/assert.hpp>
 
 namespace supreme {
@@ -58,16 +58,16 @@ private:
 
 	// TODO move to (future) communication interface class
 	void send_mode() {
-		xpcc::delayNanoseconds(50); // wait for signal propagation
+		modm::delayNanoseconds(50); // wait for signal propagation
 		rs485::read_disable::set();
 		rs485::drive_enable::set();
-		xpcc::delayMicroseconds(1); // wait at least one bit after enabling the driver
+		modm::delayMicroseconds(1); // wait at least one bit after enabling the driver
 	}
 	void receive_mode() {
-		xpcc::delayMicroseconds(1); // wait at least one bit before disabling the driver
+		modm::delayMicroseconds(1); // wait at least one bit before disabling the driver
 		rs485::read_disable::reset();
 		rs485::drive_enable::reset();
-		xpcc::delayNanoseconds(70); // wait for signal propagation
+		modm::delayNanoseconds(70); // wait for signal propagation
 	}
 };
 


### PR DESCRIPTION
## Discussion
- Include modm as submodule or not? `embedded/modm`
  → pro: versioning of modm
- Check generated modm lib into git? `embedded/firmware/modm`
   → they recommend to do so: See [here](https://modm.io/guide/getting-started/#generate-and-compile)

## Todo
- [ ] Timer0 is now automatically configured by modm for the systemClock, so it can't be used for the timing of motor cycles.
  - rewrite the logic to use `modm:processing:timer` software timers

- [ ] update the docs (steps: installation, `lbuild build`, `scons`)